### PR TITLE
Add a bunch more Shakashaka puzzles, and a few other types

### DIFF
--- a/lipuzzles.js
+++ b/lipuzzles.js
@@ -16,6 +16,8 @@ const cannedPuzzles = [
         "448.7e8.930.6c8.a58.da8.2d0.d68.298.860",        // 2014 Box #1
   "10x10:120.ad8.988.6d0.538.6c8.f30.298.dc8.220:" +
         "928.b50.928.e90.968.a90.5c8.d28.6d8.920",        // 2014 Box #2
+  "10x10:120.ab8.598.a48.898.a48.4b8.c48.360.888:" +
+        "490.fe8.9b8.fe8.5f0.a98.be0.7b8.858.200",        // godzilla 139
   // D2
   "10x10:288.d70.308.e18.110.4e8.fb0.888.a20.580:" +
         "6c0.998.eb0.9d8.730.f98.b58.7a8.968.498",        // 2014 Box #3
@@ -23,6 +25,10 @@ const cannedPuzzles = [
         "908.6b0.b48.798.960.cd0.aa8.6d0.818.420",        // 2014 Box #4
   "10x10:980.6c8.a98.5c8.c68.b50.6e8.9c0.e78.120:" +
         "520.a48.5b0.b38.1c8.498.b50.aa8.cf0.128",        // 2014 Box #5
+  "10x18:040.a18.560.948.0a0.908.a28.a78.940.7e0." +
+        "a38.a88.840.d30.b48.b28.6b0.268:" +
+        "61210.bad50.da9c8.dfa90.de6b0." +
+        "ceba8.bd7e0.dab80.99d58.62820",                  // godzilla 142
   // D3
   "10x10:890.728.8b0.1a8.e50.de8.d28.d58.6c8.120:" +
         "300.d10.908.590.e68.5b0.458.9b0.690.908",        // 2014 Box #6
@@ -59,7 +65,7 @@ let puzzleCount = cannedPuzzles.length;
 // which puzzles have demos
 const demoPuzzles  = [1,2];
 // which puzzles are at which level [D1,D2,D3,D4]
-const puzzleLevels = [1,4,7,10];
+const puzzleLevels = [1,5,9,12];
 
 const demoText = [
  ["<p>In this demo we will walk through the steps of solving this puzzle. " +

--- a/mypuzzles.js
+++ b/mypuzzles.js
@@ -30,6 +30,9 @@ let cannedPuzzles = [
   // D3
   "10x10:h1a.a11a2b1a1.a1d2c.h1a.1i.a1b1d1.1a2a1a11b.h1a.j.a1b2a22b",           // 6 17 2018 #12 pretty brilliant
   "10x10:g2b.a2h.b2f2.1d2a1b.d1e.b22b2c.g1a1.c22e.b1d2b.g1b",                   // 11 7 2024 #14 pretty tough, nice
+  "17x17:b1c1c2f.b1k11a.d1c1a2a2a21a.a2a1c21h.b1d2b11a11b.b1e2a21a12b.q." +
+        "c2f1f.112a2a2c1a22c.h11e11.c1a11j.e1b2a12b2b.2a2g11e.1e22g11." +
+        "d1h11b.2a2f1a2a11b.d1l",                                               //      v189 #5 elegant
   "17x17:b2b1b2a1f.o2a.1c2d1g.e1a2d1a2a1.1c1b2c2e.b2i1d.b2g2c1b." +
         "d2b1h2.1g1d1a1a.1a2c1a1b1e.c11g2b1a.a1e1i.d22b1a1a1a1a1." +
         "j1a1b2a.1a1c2j.h2a1f.b22d1a1b2b2",                                     // 24 37 2018 #15
@@ -62,7 +65,7 @@ let puzzleCount = cannedPuzzles.length;
 // which puzzles have demos
 const demoPuzzles =  [1,3];
 // which puzzles are at which level [D1,D2,D3,D4]
-const puzzleLevels = [1,4,11,19];
+const puzzleLevels = [1,4,11,20];
 
 const demoText = [
  ["<p>In this demo we will walk through the steps of solving this puzzle. " +

--- a/render.js
+++ b/render.js
@@ -1460,7 +1460,7 @@ function canvasSuccess(isdemo,gamename,gamenum) {
     let isNewRibbon = false;
     if (gameStorage != null) {
       gamesWon = gameStorage.split(",");
-      if (gamesWon.indexOf(gamenum) == -1) {
+      if (gamesWon.indexOf(gamenum.toString()) == -1) {
         isNewRibbon = true;
       }
     } else {
@@ -1468,7 +1468,7 @@ function canvasSuccess(isdemo,gamename,gamenum) {
       isNewRibbon = true;
     }
     if (isNewRibbon) {
-      gamesWon.push(gamenum);
+      gamesWon.push(gamenum.toString());
       const ribbonBar = document.getElementById("ribbonbar");
       ribbonBar.appendChild(returnRibbon(gamenum));
       localStorage.setItem("OPSaved" + gamename,gamesWon.join(","));

--- a/shakashaka.js
+++ b/shakashaka.js
@@ -295,7 +295,8 @@ function handleKey(keynum) {
         }
         break;
       case KEY_SP: // toggle through white -> NE -> SE -> SW -> NW -> white
-        if (puzzleBoardStates[globalCursorY][globalCursorX] == CELL_WHITE) {
+        if ((puzzleBoardStates[globalCursorY][globalCursorX] == CELL_WHITE) ||
+            (puzzleBoardStates[globalCursorY][globalCursorX] == CELL_DOT)) {
           addMove(CELL_DIAGONAL_NE,globalCursorY,globalCursorX);
         } else if (puzzleBoardStates[globalCursorY][globalCursorX] == CELL_DIAGONAL_NW) {
           addMove(CELL_WHITE,globalCursorY,globalCursorX);

--- a/shpuzzles.js
+++ b/shpuzzles.js
@@ -13,38 +13,126 @@ let cannedPuzzles = [
   "6x6:b2c.b*b*.a*c2.f.c*b.2c*1",
   // D1
   "8x8:2f0.c*d.d4c.1d3b.e*b.1g.c*c2.1b*b2*",                          // v189 #1
+  "10x10:1b**b2b.2c3b*b.e4d.j.c*c*b.c*d3*.3c4d*.j.j.2e3b2",           // box2014 #1
+  "10x10:2b3d21.j.d*e.2b4d*a.*3h.*c*e.e4d.f*b3.2b*c3b.c12b2b",        // 2018 #1
   "8x8:00b1c.h.h.b4c*1.2*c*b.h.h.c3b*1",                              // v189 #2
+  "10x10:1c0d2.*i.j.b*c4b3.3b4f.d4e.j.h31.a2h.a0c3d",                 // 2018 #2
+  "10x10:b2*f.d3e.e4c3.b3c4c.g*b.i2.3c0b*b.j.j.2e2b0",                // 2018 #3
   "10x10:b1*2e.b1*f.1b*d32.*b*2b4b.b1g.e*c3.1**g.2b4b4c.e3c2.e2b**",  // v189 #3
+  "10x10:1c22d.j.f4b2.3b21e.j.d3e.c3b4b3.j.c1f.b2*1d1",               // box2014 #2
+  "10x10:2b3d0*.h21.e*d.j.d2d1.3d3d.j.d4e.12h.*1d2b0",                // 2018 #4
   "10x10:2b*1e.d3e.h*1.f4c.b4b*d.c3f.i3.e*d.d3b3b.0c2b1b",            // v189 #4
+  "10x10:b3d3b.j.i*.*d2d.d4e.c2d30.3i.j.j.b0c3b2",                    // 2018 #5
+
   // D2
   "10x10:2d3c*.i2.d4e.e4d.j.0c3b4b.j.i3.c2f.c2b1c",                   // v189 #5
+  "10x10:b3d3b.j.f4c.0b1f.d1e.i3.*i.e*d.j.2c2b3b",                    // box2014 #3
+  "10x10:0i.j.e3b2a.d*2b*a.3b4f.b*d4b.h*2.j.j.2b3b3b2",               // 2018 #6
+  "10x10:*d3d.1i.h32.c2f.b4b13c.1*h.*c3c*1.b4g.j.c***2c",             // 2018 #7
   "10x10:d3b1b.j.j.3h1.e2d.d4e.3h2.j.j.b2b1d",                        // v189 #6
+  "10x10:*e1c.j.h2*.1i.c0f.b2d2b.i3.j.1i.*c3b*b",                     // box2014 #4
+  "10x10:2b3b3c.j.j.g0b.j.2a0a3e.h21.i1.f22b.1b3c1b",                 // 2018 #8
+  "10x10:b*2b*b2.b2g.2i.c4b2a2a.b3g.f*c.c*f.2c4d2.e3d.b2d2b",         // 2018 #9
   "10x10:g2b.b2g.e3d.j.b0f2.c2f.d2b1b.j.j.b2c3c",                     // v189 #7
+  "10x10:e2c0.e2c2.j.3b4f.j.d3e.j.13d2b3.f2c.b3g",                    // box2014 #5
+  "10x10:0b*b2b*.j.j.*b0b*b3.j.j.2b3b4b*.j.j.*b3b*b2",                // 2018 #10
+  "10x10:b3d0b.j.j.*3c3a2b.b4g.j.f3b2.12h.j.d3d2",                    // 2018 #11
   "10x10:*h1.2h2.b20b*c.f1c.j.b*f*.b1f1.j.e*d.*1c0d",                 // v189 #8
+  "10x10:1**0d21.j.j.b2g.e4c1.3c3e.g3b.j.j.*0d20*0",                  // box2014 #6
+  "10x10:02b3d*.i0.j.e3d.c3e2.*e3c.d3e.j.2i.1d0b1*",                  // 2018 #12
+  "10x10:2c0d0.j.j.c4b3c.d**b3a.d11d.3b3b3c.i2.d2e.g2b",              // 2018 #13
+  "10x10:a2e3b.j.h2*.c1f.22d1c.i2.c4f.2i.j.b2e2*",                    // 2018 #14
+  "17x17:2c0c*c2c1.d2c3h.d*d4g.e2k.0d3h20*.f3e*2c.k0e.b4n." +
+        "2*m**.n3b.e3k.c*3e4f.1*2h3d1.k1e.g2d*d.h*c1d." +
+        "0c3c0c*c2",                                                  // 2018 #17
   // D3
   "10x10:c2e*.c2e*.i0.f3b2.3b2f.d3e.e2d.*i.j.b11*e",                  // v189 #9
   "10x10:*c3b1b.2f*b.i2.e3d.c1f.b**f.b1e**.***d4b.*c2e.0c*1d",        // v189 #10
+  "10x10:b3g.f3c.3b3e3.e3d.j.j.b3b3d.3i.c3f.g3b",                     // 2018 #15
+  "10x10:1b1c3b.*i.i1.b*g.c3e1.2b3f.b2g.e2b11.e1d.b1b*d",             // 2018 #16
   "17x17:**b2****c2d.e2b2c*d.n*b.o3*.2c3e0e*.*3c4c*f*.f*h2*.q." +
         "h3h.3c0d4g.c0**d3c1*2.d0***d1*c.e*g0c.a*f1h.i1g.c2f*f." +
         "1*a*2e1b2b2",                                                // v189 #11
+  "17x17:12f0d*c.h1h.j2c*b.d4h2c.0d4f4b20.f2j.q.i4g.c3c1d*c2." +
+        "*b1b*f0b*.0d1h***.q.l*d.*3i4e.2i*e3.c1m.c**c2**2e",          // box2014 #7
+  "17x17:11b0c0c3c0.d0c1h.d3e12e.l3d.f*i2.f3b2e10.3p.e2k." +
+        "c3b4g3b.b*g0d10.q.*a0d*i.f4d*d2.e4d3f.3c*l.i3f2." +
+        "b*a0c21e2*",                                                 // 2018 #18
   "17x17:1*2b2c21b22b.q.l2d.q.*b3k30.1i3f.0e3b2c3c.e3k.q.k4e." +
         "c3c*b4e2.f*i0.22k2b2.q.d3l.q.b2*b20c2b11*",                  // v189 #12
+  "17x17:c211c012b3b.e*k.2p.c3g3**b1.c*b20h0.2b3b2h*1.*j30d." +
+        "1k3d.q.d2k1.d*2j*.1*h*b3b2.*h1*b0c.0b**3g3c.p2.k3e." +
+        "b3b202c**1c",                                                // 2018 #19
+  "17x17:c3d*b2b2b.q.2e2i3.c2m.g4f1b.j2f.c3m.h3c2d.p3.2p." +
+        "f3b2c*c.p3.g3i.b2g3c3b.h3g1.2p.d3d3b2d",                     // 2022 #18
   "17x17:2p.f2d3e.e2f3d.d2b4e3b1.*g4h.i3f1.f*j.b4n.c4f1c3b.d4l." +
         "e*a3c2d3.j4b4c.f*b4g.h4f3a.c2j4b.d2d3c3c.a2c2k",             // v189 #13
+  "17x17:02b3b*b1c3b.q.c3e3f*.2c*c2h.e4k.p2.a3e1h0.b*e0f1a." +
+        "c4e*2b2c.l*d.1*2m2.i1e30.j**1d.e33f2c.0c4j31.k1e." +
+        "g11b1b3b",                                                   // box2014 #8
+  "17x17:b3b3d2e1.p*.l31b0.e32b3g.d3d*g.i2d3b.121b2h3b." +
+        "c**e13e.i0f2.2d1*b2g.b*f2c1c.b*d1i.1f*h2.*f2i." +
+        "*b01*h3b.k2b2b.f3d2b1b",                                     // 2018 #20
+  "17x17:2b3b1c2b1b0.q.q.2b4b1c4b3b1.q.q.1b2b0c3b2b3.q.q.q." +
+        "0b3b4c2b4b1.q.q.2b3b2c3b3b1.q.q.2b3b2c3b1b0",                // 2018 #21
+  "17x17:0c2d3b2*c.e3i20.q.q.3b31f1e.e2d00e.f1j.p2.0d4i3a." +
+        "a1i*e.b1g1f.q.a3e4h3.2g2b*3d.h1b2e.e0k.2c0*j0",              // 2022 #19
+  "17x17:2h2f2.q.c3d3h.d*h1c.2d*d*e1.q.i*c3c.b3c3g3b.c2c3c2e." +
+        "q.f2f*b2.1p.q.b1b2f0c2.k1e.q.2e3f2b2",                       // box2014 #9
+  "17x17:1c*b1**c3b*.*f*0h.2p.d4i**2.e3*f0c.m1c.a*k*b*." +
+        "b*g0f.f2*a02f.f3f*2b.1b3k3a.c*m.c*g3e.**3i*d.p2." +
+        "h21f0.*b0c2**b3c*",                                          // 2022 #20
   "17x17:f1d2e.c*m.i1f3.q.c3m.2c4e2b2c.e2*e*d.b2i0d.l0b2a.e*c2g.q." +
         "f32b1c*b.22c3k.p3.j3f.f3j.0e2f2c",                           // v189 #14
+  "17x17:b1*e*1f.b2*1c1*1d1*.c20c11d2**.n11a.q.3c*2k.c0*0i11." +
+        "c21i***.n11a.2d*2d*1d.e2**b2*0d.f10b1*e.q.n21a." +
+        "c*2d21b**1a.b0*1c1*1b*1b.b0*d**g",                           // 2018 #22
+  "17x17:c2b3b1c2c.n*b.3f2i.c2i2c.e2k.g1c*d3.c*i1c.b*n.a3c2k." +
+        "q.f3j.k1b2b.e*b1h.0l*b3.c*j*b.e1k.b3c*f3c",                  // 2022 #21
+  "17x17:c0c3h2.l3d.3j4e.c1m.q.c3b3j.1j1b0b.g*i.f1j.e3d4f." +
+        "a*b2f*a*b0.c*d3h.q.e1i2a.3i*a2d.q.e0c8d3b",                  // 2018 #23
+  "17x17:**2d*1c201**.0p.2c2*1j.g*d2*c.b2h*0*c.b1f2**e.b*k1*1." +
+        "*b*j*b.2k2d.e*f1d.e0f*d.d**h21*.0b**c211f.1b1*l." +
+        "*e1*c3e.*e*d2d1.*e1d0c2*",                                   // box2014 #10
   "17x17:**c**c11**2b.*1c1*e*d.c*d1c3d.h1*e2a.1*e2f*0*.q.k2e." +
         "*1g2d*b.*2f*f0*.b*d2g2*.e1k.q.*1*f1e*0.a1e*1h.d2c2d*c." +
         "d*e*1c1*.b0**02c**c**",                                      // v189 #15
+  "17x17:f2e1d.1p.c1e0*1b3b.c*c3**d1b.b**3i*b.c*i**2a.q.a3o." +
+        "f*b*d3b.i022e.e2b**g.2l*1b.*1**c*e2b*.c*b21d**c." +
+        "g*1c1d.*f*i.c3d*g1",                                         // 2022 #25
+  "17x17:1*e21c12c.q.c12e2d10.g*i.0f*i.1i*c1b.1b3f2c*b.c2m." +
+        "h2h.m*c.b1c2f*b2.b3c3i*.i3f2.i1g.22d4e32c.q." +
+        "c*2c10e20",                                                  // 2018 #24
+  "17x17:d1l.g3i.f2c1b13b.2*j3d.b13m.g11**b*b2.m*b*.c32h2c." +
+        "q.1j*e.b2h*d3.b2b2*1*11f.b0n.k2c*a.g12e4b.j2b*c." +
+        "1c1e2f",                                                     // 2022 #26
+  // D4
+  "31x45:c1a0e2b2d2g2c.w3g.13h1h2k.2f4c2c11d1f2b.za4b1." +
+        "r2f4e.k0f*b*i.a3p0l.2n*k1b0.c3i3a*h*f.ze.d1o4b2c0b*." +
+        "d3n*c3g.c3c4j3l.x2b*b0.f*b3m4g.b0b*d*i2j.b2h4f*b4e4b1." +
+        "f3e3i4h.g1a3f3h4e.112d3d1r.1k1o1b.d1r2a2e.d3l2m." +
+        "a*a*d0d1b0e01c10*a.b3p*i*a.k4s.i4b2h4i.c*w01b.l*d4e3b1d." +
+        "a*d1d3l*f.c3l2b4k.n1b4l3.f0p2c32b.3b*b0b2i4d4f.e*d2i2j." +
+        "q3m.m3c1j3a0.c1a*d0*i4b*b2c.b3s2h.f1k2j3a.i3b1d4c3i." +
+        "ze.e2y.0c2*2e0d21b3d0c2",                                    // 2018 #25
+  "31x45:2b3c2b1c3f0c20b0*.z*b*1.d2d4g0h1d.h*q1d.0a2d4l3h1*." +
+        "e1n0a*f**.z*b0*.w3a**b*1.3u4c0d.e**3j3*2*d*d.d4l4h1d." +
+        "2h3f3i1d.*1d*b22e1b4b3b3*d.e4d1c3*1f*b2d.d*e*a*j3e1*." +
+        "l3c3l1*.01c*b4d*g4d2d.b1d3r1d.b0c*h4d*d3*b2a.e4j4d*d2d." +
+        "b*n*d2h.a**o4c*f2a.s*c4b2d.t4c*a0d.2*x0d.b4p3f2d." +
+        "c3n22b1d*0b.2b*3l21l.e3p2h.f*h3c***b4f.f0g4b2b3j." +
+        "001c*a3d3c*h2d.f1b4g**h*b2.l02c2j4b.c3d4g*n.02b4d*e4n3." +
+        "k4b*p.h*d3*p.f4g*p.3j*d4m1.h*b3e4j4b.b4b4d*p*c." +
+        "h2e0d3f3c3.d*i*d*2e*d.0c1b1b3c0d1*2c0b2b",                   // genius 64
 ];
 
 let puzzleChoice = 1;
 let puzzleCount = cannedPuzzles.length;
 
 // which puzzles have demos
-const demoPuzzles =  [1,2,6];
+const demoPuzzles =  [1,2,13];
 // which puzzles are at which level [D1,D2,D3,D4]
-const puzzleLevels = [1,6,10,99];
+const puzzleLevels = [1,13,31,57];
 
 const demoText = [
  ["<p>In this demo we will walk through the steps of solving this puzzle. " +

--- a/skpuzzles.js
+++ b/skpuzzles.js
@@ -32,6 +32,8 @@ let cannedPuzzles = [
         "g6b.b6b5c6.c4dAa.a3d6c.d8e.4a5c2c",                                    // godzilla 272 "nice"
   // D3
   "10x10:9h9.e9d.dAe.c4b6c.aCe3b.b4e3a.c3b4c.e5d.d7e.4h8",                      // v189 #4
+  "17x17:bAc86b2c5b.m6c.8c8c74b9c6.o6a.b6c4c79b2b.q.2c5g46b3.h6h.a34d3a6d32a." +
+        "h7h.4b35g2c8.q.bAb24c6cAb.a8o.6c4b26cCc9.c2m.b6c4b42c3b",              // v189 #6 "methodical and fun"
   "17x17:2a2a2a3i6.i2a6a2c.2a9a4a6c2a2a2b.i6a2a2a4a.2a2a6a3c2a2a3b.i4a2a2a4a." +
         "4a4a6a4c2a2a3b.k2a2a6a.h4h.a8a2a6k.b3a3a3cAaCa2a6.a2a2a2a2i." +
         "b2a2a2c4a3a6a2.a2a2a2a3i.b3a2a4c2a9a2a2.c6a4a9i.6i2a2a2a4",            // 2014 #7

--- a/slpuzzles.js
+++ b/slpuzzles.js
@@ -45,6 +45,9 @@ let cannedPuzzles = [
         "b23b13b.22b23b32.03b10b22.b03b12b.b22b31b.12b30b03.31b22b23." +
         "b12b21b.b32b32b.22b23b21.13b02b33",                            // vol3 #48
   // D3s
+  "15x15:d2j.3123c11232b3.c1b222b0213.b2313c2a2a1a.2b3b2b31d.a20323d12a12." +
+        "2a2211c210222.3212a2b223a1a2.232222b1a03b3.c3a3e21a3.c20a131222b2." +
+        "b12a2b2a1a2a3.2b2222a21d1.3b1h2a2.323333b2b1c",                // another GC puzzle
   "25x15:b2a3a3a0f2f1a1.33b2a2b3322e331a1a0.c2c3e3c2d3b.103e3312b3a2b020a23." +
         "e3f2a3a3a3c1b.122e211a2a2a2a2a1a1a2.c2c3d1c2a3a1a2b." +
         "20b2a3b231a123b1a3b23.b3a2a3a3c1d3c3c.2a3a3a1a1a1a3a232e113." +
@@ -81,7 +84,7 @@ let puzzleCount = cannedPuzzles.length;
 // which puzzles have demos
 const demoPuzzles =  [1,7];
 // which puzzles are at which level [D1,D2,D3,D4]
-const puzzleLevels = [1,11,19,22];
+const puzzleLevels = [1,11,19,23];
 
 const demoText = [
  ["<p>In this demo we will walk through the steps of solving this puzzle. " +

--- a/yajilin.js
+++ b/yajilin.js
@@ -279,6 +279,12 @@ function addMove(moveType,y,x,noHistory=false) {
     }
     return;
   }
+  // a dot on a black cell clears it and adds the dot
+  if ((puzzleBoardStates[y][x] == CELL_BLACK) && (moveType == PATH_DOT)) {
+    puzzleBoardStates[y][x] = CELL_WHITE;
+    globalLineStates[y][x] = PATH_DOT;
+    return;
+  }
   // the rest are path changes, make sure they're legal
   // don't try and add paths that move into a black or fixed cell or edge or black cell
   if (puzzleBoardStates[y][x] == CELL_BLACK) {


### PR DESCRIPTION
This adds a bunch more (38?) Shakashaka puzzles, which was under-accounted for, as well as a few LITS, Masyu, Shikaku, and Slitherlink. In addition, it fixed a minor bug in Slitherlink and Yajilin, and a common one for ribbon accounting.