### PR TITLE
improve readability of HTML files

### DIFF
--- a/akari.html
+++ b/akari.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./puzzles.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans|Hina+Mincho"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./akpuzzles.js"></script>
@@ -28,17 +28,33 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          A left-click on the board adds a light bulb to a white
-          square, or removes one that is already there. Alternately
-          you can use arrow keys to move around the board, and press
-          the space bar to toggle light bulbs, or the '1' key to add
-          a bulb, or '0' key or backspace to remove. You can right-click
-          or press the '.' button to put a dot place-holder for a cell
-          that, by your determination, can not contain a light bulb
-          (for instance next to a '0' black cell).
+          The goal of the game is to set light bulbs on the board
+          to illuminate all white cells (see rules). There are several
+          ways to set elements on the board:
+          <ul>
+            <li>
+              A <b>left-click</b> on the board adds a light bulb to a white
+              square, or removes one that is already there.
+            </li>
+            <li>
+              Once the board has been selected, you can use arrow keys
+              to move around the board, and press the <b>space bar</b>
+              to toggle light bulbs.
+            </li>
+            <li>
+              You can press the <b>'1'</b> key to add a bulb, or <b>'0'</b> key or
+              <b>backspace</b> to remove.
+            </li>
+            <li>
+              You can <b>right-click</b> or press the <b>'.' button</b>
+              to put a dot place-holder for a cell that, by your determination,
+              can not contain a light bulb (for instance next to a '0'
+              black cell).
+            </li>
+          </ul>
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or un-illuminated white cells  is indicated.  In Assist Mode
           (1), the number of errors and incomplete cells is indicated,
           see game rules.  In Assist Mode (2), errors and illuminated rooms
@@ -49,12 +65,12 @@
           the "undo" button on the bottom of the page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
-          which will walk you through a solve to help you on the path to
-          mastery: <span id='demolist1'>[]</span>).
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have
+          <b>demos</b>, which will walk you through a solve to help you
+          on the path to mastery: <span id='demolist1'>[]</span>).
         </p>
       </div>
       <div id="tab2" class="tab_content" style="display: none;">
@@ -93,11 +109,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/chocobanana.html
+++ b/chocobanana.html
@@ -28,18 +28,45 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To play, click on a cell to switch between light, dark, and the
-          default indeterminate state.  A left-click turns it black, a
-          right-click turns to white, and a middle-click returns to
-          indeterminate. Once the mouse is pressed down, you can drag
-          the mouse to set multiple squares in one sequence.
-          Alternately, you can use the arrow keys to move
-          around the board, and press the space bar to toggle between
-          the states, or the '1' key to turn black, the '0' key to turn
-          white, or the backspace key to set back to indeterminate.
+          In Choco Banana, the goal is to convert all cells from
+          the indeterminate gray state to black or white to create
+          "rooms" of appropriate sizes (see Rules tab). To play,
+          you can use the mouse to click or arrow and button keys
+          to change colors:
+          <ul>
+            <li>
+              A <b>left-click</b> on a cell turns it black.
+            </li>
+            <li>
+              A <b>right-click</b> on a cell turns it white.
+            </li>
+            <li>
+              A <b>middle-click</b> on a cell turns returns it to
+              indeterminate gray.
+            </li>
+            <li>
+              Once the mouse is pressed down, you can <b>drag the mouse</b>
+              to set multiple squares in one sequence.
+            </li>
+            <li>
+              Alternately, once on the board, you can use the
+              <b>arrow keys</b> to move around the board, and press
+              the <b>space bar</b> to toggle between the states, or
+            </li>
+            <li>
+              press the <b>'1' key</b> to turn black, or
+            </li>
+            <li>
+              press the <b>'0' key </b> to turn white, or
+            </li>
+            <li>
+              press the <b>backspace key</b> to set back to indeterminate.
+            </li>
+          </li>
+        </ul>
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete rooms is indicated.  In Assist Mode (1), the
           number of errors and incomplete rooms is indicated, see game rules.
           In Assist Mode (2), errors and completed rules are highlighted
@@ -50,12 +77,12 @@
           the "undo" button on the bottom of the page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
-          which will walk you through a solve to help you on the path to
-          mastery: <span id='demolist1'>[]</span>).
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example
+          completed puzzle that can be helpful. The following puzzle codes
+          have <b>demos</b>, which will walk you through a solve to help you
+          on the path to mastery: <span id='demolist1'>[]</span>).
         </p>
       </div>
       <div id="tab2" class="tab_content" style="display: none;">
@@ -93,13 +120,13 @@
             number.
           </li>
         </ol>
-        Below select puzzle 0 to see a completed sample grid.
+        Below select <b>puzzle 0</b> to see a completed sample grid.
         See the Game Play or Puzzles tab for how to invoke a demo.
       </div>
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.

--- a/doublechoco.html
+++ b/doublechoco.html
@@ -3,8 +3,8 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <link rel="stylesheet" href="./puzzles.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./dcpuzzles.js"></script>
@@ -28,16 +28,35 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To play, left-click on a border between cells to create a wall
-          between cells, or right-click to remove a wall. You can drag
-          around to continue to draw the wall, or erase the wall. Alternately,
-          once on a boundary, you can shift-move to add more borders in the
-          direction of arrow keys. Additionally, if the cursor is on a wall,
-          you can press the space bar to toggle the wall state, or press
-          '1' to set, or '0' or backspace to clear.
+          In Double Choco, the goal is to draw border walls around cells
+          to satisfy the goals of the game (see rules tab). To draw
+          borders, you can use the mouse or arrow and button keys:
+          <ul>
+            <li>
+              A <b>left-click</b> on a border between cells creates
+              a wall between cells
+            </li>
+            <li>
+              A <b>right-click</b> on an existing wall removes it.
+            </li>
+            <li>
+              You can <b>mouse drag</b> around to continue to draw
+              the wall, or erase the wall.
+            </li>
+            <li>
+              Once on a boundary, you can press the <b>shift key</b>
+              and then <b>arrow keys</b> to add border walls in the
+              direction of the arrow keys.
+            </li>
+            <li>
+              Once on a wall, you can press the <b>space bar</b> to
+              toggle the wall state, or press the <b>'1' key</b>
+              to set, or <b>'0' key</b> or backspace to clear a wall.
+            </li>
+          </ul>
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete numbers is indicated.  In Assist Mode (1), the
           number of errors and incomplete numbers is indicated, see game rules.
           In Assist Mode (1) or higher, each numbered square is given a different
@@ -53,10 +72,10 @@
           to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have <b>demos</b>,
           which will walk you through a solve to help you on the path to
           mastery: <span id='demolist1'>[]</span>).
         </p>
@@ -95,11 +114,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/fillomino.html
+++ b/fillomino.html
@@ -28,27 +28,70 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To play, click on a cell and enter a digit. Once selected, arrow
-          keys can be used to move around the canvas. Use keys 1-9, or A-Z
-          for double digit values 10-35. Bold digits are the initial puzzle
-          values.  You can also click on an existing number and "drag" it
-          to other cells to overwrite their value with its value. Similarly
-          you can press and hold the shift key, then use the arrow keys to
-          move around the board to propagate the current number to other
-          cells. To remove an entered number, you can right-click the cell,
-          or press the back space to clear. You can also drag a cleared
-          cell to clear out new cells.
+          In Fillomino, the goal is to place a number in every cell in
+          order to complete the puzzle according to the rules (see
+          Rules tab). To play, you can click on a cell or move around
+          with the arrow keys, then enter a digit.
+          <ul>
+            <li>
+              Use the mouse <b>left-click</b> to move the cursor to
+              a desired cell.
+            </li>
+            <li>
+              Once selected, <b>arrow keys</b> can be used to move
+              around the canvas.
+            </li>
+            <li>
+              Use digit keys <b>1-9</b> to enter a single-digit value
+            </li>
+            <li>
+              Use letter keys <b>A-Z</b> for double digit values 10-35,
+              respectively.
+            </li>
+            <li>
+              Bold digits are the initial puzzle values, and can not
+              be overwritten.
+            </li>
+            <li>
+              You can also <b>left-click</b> on an existing number 
+              and "drag" it to other cells to overwrite their value
+              with its value.
+            </li>
+            <li>
+              Similarly you can press and hold the <b>shift key</b>,
+              then use the <b>arrow keys</b> to move around the board
+              to propagate the current number to other cells.
+            </li>
+            <li>
+              To remove an entered number, you can <b>right-click</b>
+              the cell, or press the <b>back space</b> to clear.
+            </li>
+            <li>
+              You can also drag a cleared cell with the mouse
+              <b>left-click</b> or <b>shift- and arrow keys</b>
+              to clear out new cells.
+            </li>
+            <li>
+              For visualization of numerical boundaries, you can
+              <b>left-click</b> on a cell border between cells to make
+              a note of expected numeric separations, though no error
+              checking is made.
+            </li>
+            <li>
+              You can <b>right-click</b> to remove drawn borders, but
+              not calculated ones.
+            </li>
+            <li>
+              Once on a boundary, you can <b>shift- arrow move</b> to add
+              more borders. You can also <b>drag left-click</b> to
+              draw borders, or <b>drag right-click</b> to clear borders.
+            </li>
+          </ul>
         </p>
         <p>
-          For visualization of numerical boundaries, you can left-click on
-          borders between cells to make a note of expected numeric separations,
-          though no error checking is made. You can right-click to remove
-          drawn borders, but not calculated ones. Once on a boundary, you can
-          shift-move to add more borders. You can also drag left-click to
-          draw borders, or drag right-click to clear borders.
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete numbers is indicated.  In Assist Mode (1), the
           number of errors and incomplete numbers is indicated, see game rules.
           In Assist Mode (1) or higher, each numbered square is given a different
@@ -62,12 +105,12 @@
           the "undo" button on the bottom of the page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
-          which will walk you through a solve to help you on the path to
-          mastery: <span id='demolist1'>[]</span>).
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have
+          <b>demos</b>, which will walk you through a solve to help you
+          on the path to mastery: <span id='demolist1'>[]</span>).
         </p>
       </div>
       <div id="tab2" class="tab_content" style="display: none;">
@@ -110,11 +153,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/hashi.html
+++ b/hashi.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./puzzles.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans|Hina+Mincho"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./hkpuzzles.js"></script>
@@ -28,27 +28,49 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
+          In Hashiwokakero, the goal is to create bridges between
+          circles in order to complete the puzzle (see Rules tab).
           There are several ways to create and remove bridges.
-          The user can start at a circle and drag the left mouse
-          towards one of the four directions to indicate the
-          creation of the bridge in that direction.  The environment
-          will extend the bridge to the next nearest circle, and
-          will not allow the user to create illegal bridges (i.e.
-          in the direction of a wall with no other circles, or into
-          another perpindicular bridge). Alternately you can use the
-          arrow keys to move around the board, and hold down the shift
-          key followed by an arrow key to create a bridge in that
-          direction. Or, you can press one of the directional
-          keys N, S, E, W to create a bridge in that direction.
-          Once a bridge has been created, the user can
-          left-click on it a second time to double-bridge it, or 
-          a third time to delete it. Or the right-mouse click can
-          remove a bridge. Pressing the directional key N, S, E or W
-          converts a single bridge in that direction to a double
-          bridge, or erases a double bridge.
+          <ul>
+            <li>
+              The user can start at a circle and drag the <b>left
+              mouse</b> towards one of the four directions to
+              indicate the creation of the bridge in that direction.
+              The environment will extend the bridge to the next
+              nearest circle, and will not allow the user to create
+              illegal bridges (i.e. in the direction of a wall
+              with no other circles, or into another perpindicular
+              bridge).
+            </li>
+            <li>
+              Alternately the user can use the <b>arrow keys</b>
+              to move around the board, and hold down the <b>shift
+              key</b> followed by an <b>arrow key</b> to create a
+              bridge in that direction.
+            </li>
+            <li>
+              Alternately, once on a circle, you can press one
+              of the directional keys <b>N, S, E, W</b> to create
+              a bridge in that direction.
+            </li>
+            <li>
+              Once a bridge has been created, the user can
+              <b>left-click</b> on it a second time to double-bridge it
+              (see rules), or a third time to delete it.
+            </li>
+            <li>
+              The user can also <b>right-click</b> the mouse to
+              remove a bridge.
+            </li>
+            <li>
+              Pressing the directional keys <b>N, S, E</b> or <b>W</b>
+              converts a single bridge in that direction to a double
+              bridge, or erases a double bridge.
+            </li>
+          </ul>
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete numbers is indicated.  In Assist Mode (1), the
           number of errors and incomplete numbers is indicated, see game rules.
           In Assist Mode (2), errors and completed rules are highlighted
@@ -61,12 +83,12 @@
           the "undo" button on the bottom of the page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
-          which will walk you through a solve to help you on the path to
-          mastery: <span id='demolist1'>[]</span>).
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have
+          <b>demos</b>, which will walk you through a solve to help you
+          on the path to mastery: <span id='demolist1'>[]</span>).
         </p>
       </div>
       <div id="tab2" class="tab_content" style="display: none;">
@@ -102,11 +124,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/heyawake.html
+++ b/heyawake.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./puzzles.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans|Hina+Mincho"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./heyawake.js"></script>
@@ -28,18 +28,36 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To play, click on a cell to switch between light, dark, and the
-          default indeterminate state.  A left-click turns it black, a
-          right-click turns to white, and a middle-click returns to
-          indeterminate. Once the mouse is pressed down, you can drag
-          the mouse to set multiple squares in one sequence.
-          Alternately, you can use the arrow keys to move
-          around the board, and press the space bar to toggle between
-          the states, or the '1' key to turn black, the '0' key to turn
-          white, or the backspace key to set back to indeterminate.
+          In Heyawake, the goal is to color squares white or black
+          in order to satisfy the goals of the game (see Rules tab).
+          To play, you can use the mouse or button and arrow keys
+          to change cell colors:
+          <ul>
+            <li>
+              A mouse <b>left-click</b> turns a cell black, a
+              <b>right-click</b> turns it to white, or a
+              <b>middle-click</b> turns it back to the default
+              gray indeterminate state.
+            </li>
+            <li>
+              Once the mouse is pressed down, you can <b>drag</b>
+              the mouse to set multiple squares in one drawing.
+            </li>
+            <li>
+              In addition, you can use the <b>arrow keys</b> to move
+              around the board, and then press keys to set cell
+              colors.
+            </li>
+            <li>
+              Press the <b>space bar</b> to toggle between the
+              states, or the <b>'1'</b> key to turn black, the
+              <b>'0'</b> key to turn white, or the <b>backspace</b>
+              key to set back to indeterminate.
+            </li>
+          </ul>
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete rooms is indicated.  In Assist Mode (1), the
           number of errors and incomplete rooms is indicated, see game rules.
           In Assist Mode (2), errors are highlighted with digit colors, and
@@ -51,12 +69,12 @@
           page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
-          which will walk you through a solve to help you on the path to
-          mastery: <span id='demolist1'>[]</span>).
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have
+          <b>demos</b>, which will walk you through a solve to help you
+          on the path to mastery: <span id='demolist1'>[]</span>).
         </p>
       </div>
       <div id="tab2" class="tab_content" style="display: none;">
@@ -94,11 +112,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/hitori.html
+++ b/hitori.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./puzzles.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans|Hina+Mincho"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./hitori.js"></script>
@@ -28,13 +28,16 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To play, click on a cell to toggle from light to dark. Alternately,
-          you can use the arrow keys to move around the board, and press
-          the space bar to toggle, or the '1' key to turn black, or the '0'
-          key to turn white.
+          In Hitori, the goal is to set some cells black in order
+          to avoid duplicate numbers in a row or column (see Rules
+          tab). To play, <b>left-click</b> on a cell to toggle from
+          light to dark. Alternately, you can use the <b>arrow keys</b>
+          to move around the board, and press the <b>space bar</b>
+          to toggle, or the <b>'1'</b> key to turn black, or the
+          <b>'0'</b> key to turn white.
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           is indicated.  In Assist Mode (1), the number of errors is
           indicated, be they duplicate digits per row or column, adjacent
           blackened cells, or stranded "rivers" of white cells. In Assist
@@ -46,12 +49,12 @@
           to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
-          which will walk you through a solve to help you on the path to
-          mastery: <span id='demolist1'>[]</span>).
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have
+          <b>demos</b>, which will walk you through a solve to help you
+          on the path to mastery: <span id='demolist1'>[]</span>).
         </p>
       </div>
       <div id="tab2" class="tab_content" style="display: none;">
@@ -77,13 +80,13 @@
             through diagonally adjacent white cells.
           </li>
         </ol>
-        Below select puzzle 0 to see a completed sample grid.
+        Below select <b>puzzle 0</b> to see a completed sample grid.
         See the Game Play or Puzzles tab for how to invoke a demo.
       </div>
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.

--- a/lits.html
+++ b/lits.html
@@ -4,12 +4,12 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./puzzles.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./lits.js"></script>
     <script type="text/javascript" src="./lipuzzles.js"></script>
     <script src="./jquery.js"></script>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans" />
     <title>LITS Player</title>
   </head>
   <body>
@@ -28,20 +28,36 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To play, click on a cell to switch between light, dark, and the
-          default indeterminate state.  A left-click turns it dark, a
-          right-click turns to white, and a middle-click returns to
-          indeterminate. Once the mouse is pressed down, you can drag
-          the mouse to set multiple squares in one sequence.
-          Alternately, you can use the arrow keys to move
-          around the board, and press the space bar to toggle between
-          the states, or the '1' key to turn black, the '0' key to turn
-          white, or the backspace key to set back to indeterminate.
-          Once on a cell, you can drag its color by holding the shift
-          key and moving the arrow keys up down left or right.
+          In the game LITS, the goal is to set some cells black and
+          the rest white in order to satisfy the goals of the game
+          (see Rules tab). To play, you can click on a cell to switch
+          states, or use the arrow and other keys:
+          <ul>
+            <li>
+              A <b>left-click</b> turns a cell dark, a <b>right-click</b>
+              turns it white, and a <b>middle-click</b> returns it to
+              indeterminate (gray).
+            </li>
+            <li>
+              Once the mouse is pressed down, you can <b>drag</b>
+              the mouse to set multiple squares in one sequence.
+            </li>
+            <li>
+              Alternately, you can use the <b>arrow keys</b> to move
+              around the board, then press the <b>space bar</b> to
+              toggle between the states, or the <b>'1'</b> key to turn
+              black, the <b>'0'</b> key to turn white, or the
+              <b>backspace</b> key to set back to indeterminate.
+            </li>
+            <li>
+              Once on a cell, you can drag its color by holding the
+              <b>shift</b> key and moving the <b>arrow keys</b> up
+              down left or right.
+            </li>
+          </ul>
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete rooms is indicated.  In Assist Mode (1), the
           number of errors and incomplete rooms is indicated, see game rules.
           In Assist Mode (2), errors are highlighted with different colors
@@ -54,12 +70,12 @@
           the "undo" button on the bottom of the page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
-          which will walk you through a solve to help you on the path to
-          mastery: <span id='demolist1'>[]</span>).
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have
+          <b>demos</b>, which will walk you through a solve to help you
+          on the path to mastery: <span id='demolist1'>[]</span>).
         </p>
       </div>
       <div id="tab2" class="tab_content" style="display: none;">
@@ -80,7 +96,7 @@
           <li>
             The arrangement of the dark squares must resemble the letters
             'L', 'I', 'T' or 'S'. See the completed solution using puzzle
-            entry number 0 for an example.
+            <b>entry number 0</b> for an example.
           </li>
           <li>
             Identical shapes (two 'L' shapes, for instance) can not touch
@@ -97,13 +113,13 @@
             if it only flows through diagonally adjacent dark cells.
           </li>
         </ol>
-        Below select puzzle 0 to see a completed sample grid.
+        Below select <b>puzzle 0</b> to see a completed sample grid.
         See the Game Play or Puzzles tab for how to invoke a demo.
       </div>
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.

--- a/masyu.html
+++ b/masyu.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./puzzles.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans|Hina+Mincho"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./mypuzzles.js"></script>
@@ -28,26 +28,57 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To draw a path, left click on the center of a cell to
-          begin. From there, drag the mouse in the direction to create
-          the path. The path will draw as the dragging continues. Alternately,
-          once on the board, you can press the shift key and hold while
-          moving around the board with the arrow keys. In addition, you
-          can enter a key to indicate the type of path desired for that
-          cell (and into its neighbors). These keys are as follows, and
-          will extend the line into the center of the adjoining cells:
+          In the game Masyu, the goal is to draw a single path through
+          all circles that follow the rules of the game (see Rules tab).
+          To draw a path, you can use the mouse or button keys:
           <ul>
-            <li>'-' key to draw a full horizontal line through the cell</li>
-            <li>'|' or 'I' key to draw a full vertical line through the cell</li>
-            <li>'L','J','7', or 'F' key to draw a correspondingly shaped turn in the cell</li>
+            <li>
+              With the mouse you can <b>left click</b> on the center of
+              a cell to begin a path. From there, <b>drag</b> the mouse
+              in the direction to create the path.  The path will draw
+              as the dragging continues.
+            </li>
+            <li>
+              Alternately, once on the board, you can press the
+              <b>shift key</b> and hold while moving around the board
+              with the <b>arrow keys</b>.
+            </li>
+            <li>
+              In addition, you can enter a key to indicate the type
+              of path desired for that cell (and into its neighbors).
+              These keys are as follows, and will extend the line
+              into the center of the adjoining cells:
+              <ul>
+                <li>
+                  <b>'-' key</b> to draw a full horizontal line
+                  through the cell
+                </li>
+                <li>
+                  <b>'|'</b> or <b>'I'</b> key to draw a full
+                  vertical line through the cell
+                </li>
+                <li>
+                  <b>'L','F','7'</b>, or <b>'7'</b> key to draw a
+                  correspondingly shaped turn in the cell (i.e.
+                  a left turn starting from the N, E, S, or
+                  W direction).
+                </li>
+              </ul>
+            </li>
+            <li>
+              Once created, a path can be removed by pressing
+              the <b>backspace key</b> within a white cell. This
+              deletes it just for this cell, but deletes the
+              "arms" into the adjoining cells.
+            </li>
+            <li>
+              You can also attempt to redraw with the <b>left-click</b>
+              dragging method.
+            </li>
           </ul>
-          Once created, a path can be removed by pressing the backspace
-          key within a white cell. This deletes it just for this cell,
-          but deletes the "arms" into the adjoining cells. You can also
-          attempt to redraw with the left-click dragging method.
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete numbers is indicated.  In Assist Mode (1), the
           number of errors and incomplete numbers is indicated, see game rules.
           In Assist Mode (2), errors and completed rules are highlighted
@@ -58,10 +89,10 @@
           the "undo" button on the bottom of the page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have <b>demos</b>,
           which will walk you through a solve to help you on the path to
           mastery: <span id='demolist1'>[]</span>).
         </p>
@@ -99,11 +130,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/midloop.html
+++ b/midloop.html
@@ -4,8 +4,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./puzzles.css" />
-    <script type="application/javascript" src="./fastclick.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
+    <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./mlpuzzles.js"></script>
     <script type="text/javascript" src="./midloop.js"></script>
@@ -28,26 +28,57 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To draw a path, left click on the center of a cell to
-          begin. From there, drag the mouse in the direction to create
-          the path. The path will draw as the dragging continues. Alternately,
-          once on the board, you can press the shift key and hold while
-          moving around the board with the arrow keys. In addition, you
-          can enter a key to indicate the type of path desired for that
-          cell (and into its neighbors). These keys are as follows, and
-          will extend the line into the center of the adjoining cells:
+          In the game Midloop, the goal is to draw a single path through
+          all dots that follow the rules of the game (see Rules tab).
+          To draw a path, you can use the mouse or button keys:
           <ul>
-            <li>'-' key to draw a full horizontal line through the cell</li>
-            <li>'|' or 'I' key to draw a full vertical line through the cell</li>
-            <li>'L','J','7', or 'F' key to draw a correspondingly shaped turn in the cell</li>
+            <li>
+              With the mouse you can <b>left click</b> on the center of
+              a cell to begin a path. From there, <b>drag</b> the mouse
+              in the direction to create the path.  The path will draw
+              as the dragging continues.
+            </li>
+            <li>
+              Alternately, once on the board, you can press the
+              <b>shift key</b> and hold while moving around the board
+              with the <b>arrow keys</b>.
+            </li>
+            <li>
+              In addition, you can enter a key to indicate the type
+              of path desired for that cell (and into its neighbors).
+              These keys are as follows, and will extend the line
+              into the center of the adjoining cells:
+              <ul>
+                <li>
+                  <b>'-' key</b> to draw a full horizontal line
+                  through the cell
+                </li>
+                <li>
+                  <b>'|'</b> or <b>'I'</b> key to draw a full
+                  vertical line through the cell
+                </li>
+                <li>
+                  <b>'L','F','7'</b>, or <b>'7'</b> key to draw a
+                  correspondingly shaped turn in the cell (i.e.
+                  a left turn starting from the N, E, S, or
+                  W direction).
+                </li>
+              </ul>
+            </li>
+            <li>
+              Once created, a path can be removed by pressing
+              the <b>backspace key</b> within a white cell. This
+              deletes it just for this cell, but deletes the
+              "arms" into the adjoining cells.
+            </li>
+            <li>
+              You can also attempt to redraw with the <b>left-click</b>
+              dragging method.
+            </li>
           </ul>
-          Once created, a path can be removed by pressing the backspace
-          key within a white cell. This deletes it just for this cell,
-          but deletes the "arms" into the adjoining cells. You can also
-          attempt to redraw with the left-click dragging method.
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete numbers is indicated.  In Assist Mode (1), the
           number of errors and incomplete numbers is indicated, see game rules.
           In Assist Mode (2), errors and completed rules are highlighted
@@ -58,10 +89,10 @@
           the "undo" button on the bottom of the page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle 0 shows an example of a completed
-          puzzle. The following puzzle codes have demos, which will walk
+          (see "Puzzles" tab). <b>Puzzle 0</b> shows an example of a completed
+          puzzle. The following puzzle codes have <b>demos</b>, which will walk
           you through a solve to help you on the path to mastery:
           <span id='demolist1'>[]</span>).
         </p>
@@ -102,11 +133,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/nurikabe.html
+++ b/nurikabe.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./puzzles.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans|Hina+Mincho"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./nkpuzzles.js"></script>
@@ -28,19 +28,37 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To play, click on a cell to switch between light, dark, and the
-          default indeterminate state.  A left-click turns it black, a
-          right-click turns to white, and a middle-click returns to
-          indeterminate. Once the mouse is pressed down, you can drag
-          the mouse to set multiple squares in one sequence.
-          Alternately, you can use the arrow keys to move
-          around the board, and press the space bar to toggle between
-          the states, or the '1' key to turn black, the '0' key to turn
-          white, or the backspace key to set back to indeterminate.
-          You can not alter the state of a white square with a digit.
+          In the game Nurikabe, the goal is to turn some of the board
+          cells black or white in order to create rooms of white cells
+          equivalent in size to numbers on the board (see Rules tab).
+          You can use the mouse or keys to set cells:
+          <ul>
+            <li>
+              With the mouse you can <b>left-click</b> on a cell to
+              turn it black, a <b>right-click</b> turns a cell white,
+              or a <b>middle-click</b> returns a cell to the gray
+              indeterminate set.
+            </li>
+            <li>
+              Once the mouse is pressed down, you can <b>drag</b> the mouse
+              to set multiple squares in one sequence.
+            </li>
+            <li>
+              You can use the arrow keys to move around the board, and
+              press the <b>space bar</b> to toggle between the states.
+            </li>
+            <li>
+              Alternately you can press the <b>'1'</b> key to turn black,
+              the <b>'0'</b> key to turn white, or <b>backspace</b> to
+              set back to indeterminate.
+            </li>
+            <li>
+              You can not alter the state of a white square with a digit.
+            </li>
+          </ul>
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete numbers is indicated.  In Assist Mode (1), the
           number of errors and incomplete numbers is indicated, see game rules.
           In Assist Mode (2), errors and completed rules are highlighted
@@ -51,10 +69,10 @@
           the "undo" button on the bottom of the page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have <b>demos</b>,
           which will walk you through a solve to help you on the path to
           mastery: <span id='demolist1'>[]</span>).
         </p>
@@ -97,11 +115,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/ripple.html
+++ b/ripple.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./puzzles.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans|Hina+Mincho"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./ripple.js"></script>
@@ -28,16 +28,19 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To play, click on a cell, then enter a digit value. If needed,
-          digit values greater than '9' can be entered by pressing the
-          corresponding letter from 'A' (10) to 'Z' (35). Digit values
-          greater than the largest polyomino ("room") on the board will be
-          ignored. Once on a cell, you can use the arrow keys to move
-          around the board. Press the space bar to remove an entry
-          (except those defined by the puzzle itself).
+          In the game Ripple Effect, you enter number values into cells
+          in order to complete the game according to the rules (see
+          Rules tab). To play, click on a cell, then enter a digit value
+          <b>1-9</b>.  If needed, digit values greater than '9' can be
+          entered by pressing the corresponding letter, eg. <b>'A'</b>
+          (10), <b>'B'</b> (11), etc. Digit values greater than the largest
+          polyomino ("room") on the board will be ignored. Once on a cell,
+          you can use the <b>arrow keys</b> to move around the board.
+          Press the <b>space bar</b> to remove an entry (except those
+          defined by the puzzle itself).
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete rooms is indicated.  In Assist Mode (1), the
           number of errors and incomplete rooms is indicated, see game rules.
           In Assist Mode (2), errors are highlighted with digit colors, and
@@ -49,10 +52,10 @@
           page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have <b>demos</b>,
           which will walk you through a solve to help you on the path to
           mastery: <span id='demolist1'>[]</span>).
         </p>
@@ -90,11 +93,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/shakashaka.html
+++ b/shakashaka.html
@@ -28,21 +28,44 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          A left-click on a while cell toggles through all potential
-          settings for the cell, starting with a black triangle in
-          the NE corner, then rotating SE, SW, NW, then back to white.
-          That is &#x25e5; &rarr; &#x25e2; &rarr; &#x25e3; &rarr; &#x25e4;
-          &rarr; white.  Alternately you can use arrow keys to move around
-          the board, and press the space bar to toggle through the options,
-          or press '1' - '4' to set a triangle in the corresponding corner
-          (starting with '1' for NE &#x25e5; and moving clockwise to '4'
-          for &#x25e4;), or '0' or the backspace key to return to white.
-          You can right-click or press the '.' button to put a dot
-          place-holder for a cell that, by your determination, must stay
-          white.
+          In the game Shakashaka, players create white "rooms" surrounded
+          by black borders in either an upright direction, or angled
+          at 45 degrees (see Rules tab). The black edges of these rooms
+          and be created using either the mouse or keyboard keys:
+          <ul>
+            <li>
+              A <b>left-click</b> on a white cell toggles through 5 potential
+              settings for the cell (one of 4 black triangles, or empty; the
+              rules do not allow for adding a pure black cell).
+            </li>
+            <li>
+              The rotation of states starts with a black triangle in
+              the <b>NE corner</b>, then rotating <b>SE, SW, NW</b>, then
+              back to white.  That is <b>&#x25e5; &rarr; &#x25e2; &rarr;
+              &#x25e3; &rarr; &#x25e4; &rarr; white</b>.
+            </li>
+            <li>
+              Alternately you can use <b>arrow keys</b> to move around the
+              board, and press the <b>space bar</b> to toggle through the
+              options, or
+            </li>
+            <li>
+              Press number keys <b>'1' - '4'</b> to set a triangle in the
+              corresponding corner (starting with '1' for NE &#x25e5; and
+              moving clockwise to '4' for &#x25e4;), or
+            </li>
+            <li>
+              Press <b>'0'</b> or the <b>backspace</b> key to return to white.
+            </li>
+            <li>
+              You can <b>right-click</b> or press the <b>'.'</b> key to put
+              a dot place-holder for a cell that, by your determination,
+              must stay white.
+            </li>
+          </ul>
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete numbered cells is indicated.  In Assist Mode
           (1), the number of errors and incomplete cells is indicated,
           see game rules.  In Assist Mode (2), errors and completed
@@ -54,10 +77,10 @@
           previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
           (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
+          puzzle that can be helpful. The following puzzle codes have <b>demos</b>,
           which will walk you through a solve to help you on the path to
           mastery: <span id='demolist1'>[]</span>).
         </p>
@@ -91,16 +114,16 @@
             of any size.
           </li>
         </ol>
-        Enter puzzle #0 in the tab below to see a completed puzzle.
+        <b>Enter puzzle #0</b> in the tab below to see a completed puzzle.
       </div>
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/shikaku.html
+++ b/shikaku.html
@@ -28,27 +28,42 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To play, use the mouse or arrow keys to draw rectangular rooms
-          around the different numbered cells. You can begin a rectangle
-          from any cell. Click and hold the left mouse to begin the rectangle,
-          then drag the mouse in the shape desired. For instance, if you want
-          a 2-high 3-wide rectangle over a cell with a '6' in it, click on the
-          cell describing the upper left of the rectangle, then move the
-          mouse two cells to the right and down 1 to make the 2x3 rectangle.
-          While the mouse is down you can change the shape as desired.
-          A right-click within the room removes the previous rectangle
-          and starts anew. The drawer will not allow you to create a room
-          that conflicts with an existing room. In alternate to the mouse
-          drag, you can do the same by moving around the board with the
-          arrow keys, then pressing the shift button to start a rectangle
-          shape. Pressing the backspace on a cell within a defined room
-          clears its existing rectangle. It may not always be obvious that
-          a room has been cleared if other rooms' borders coincide with
-          the borders of the deleted room. (Assist mode below can help
-          visualize drawn rooms.)
+          In the game Shikaku, the goal is to draw rectangular borders
+          around cells of the size equal to a circled number enclosed
+          (see Rules tab). To play, use the mouse or arrow keys to draw
+          the borders, or rooms:
+          <ul>
+            <li>
+              You can begin to draw a rectangle from any cell. With the
+              mouse, <b>left-click and hold</b> to begin the rectangle,
+              then <b>drag</b> the mouse in the shape desired. For
+              instance, if you want a 2-high 3-wide rectangle over a
+              cell with a '6' in it, click on the cell describing the
+              upper left of the rectangle, then move the mouse two cells
+              to the right and down 1 to make the 2x3 rectangle.  While
+              the mouse is down you can change the shape as desired.
+            </li>
+            <li>
+              A <b>right-click</b> within a room removes any prior borders
+              and starts anew.  The drawing tool will not allow you to
+              create a room that conflicts with an existing room.
+            </li>
+            <li>
+              In alternate to the mouse drag, you can do the same by moving
+              around the board with the <b>arrow keys</b>, then pressing
+              the <b>shift button</b> to start a rectangle shape,
+              expanding it in any direction with the arrow keys.
+            </li>
+            <li>
+              Pressing the <b>backspace</b> on a cell within a defined room
+              clears its existing rectangle. It may not always be obvious that
+              a room has been cleared if other rooms' borders coincide with
+              the borders of the deleted room. (Assist mode below can help
+              visualize drawn rooms.)
+            </li>
+          </ul>
         </p>
-        </p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete numbers is indicated.  In Assist Mode (1), the
           number of errors and incomplete numbers is indicated, see game
           rules.  In Assist Mode (2) completed rooms are colored green
@@ -64,10 +79,10 @@
           button on the bottom of the page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have <b>demos</b>,
           which will walk you through a solve to help you on the path to
           mastery: <span id='demolist1'>[]</span>).
         </p>
@@ -93,11 +108,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/slitherlink.html
+++ b/slitherlink.html
@@ -3,8 +3,8 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <link rel="stylesheet" href="./puzzles.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./slpuzzles.js"></script>
@@ -28,26 +28,58 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To play, left-click on a border between cells to create a line
-          between vertices, or right-click to remove a line. You can drag
-          around to continue to draw the line, or erase the line. Alternately,
-          once on a boundary, you can shift-move to add more borders in the
-          direction of arrow keys. Additionally, if the cursor is on a wall,
-          you can press the space bar to toggle the wall state, or press
-          '1' to set, or '0' or backspace to clear. You can use the
-          middle-click on a line to add an '&#xD7;' in a line space,
-          indicating that it is marked as disabled, i.e. determined by
-          the user to not be able to contain a line. Meanwhile you can
-          also click on a cell to toggle its color between the
-          default white, and gray. This has no influence on the solving
-          of the puzzle, but can help visualize the cells in between the
-          lines of the full final loop (see rules). A right-click on a
-          cell clears it back to white. Also, once on a cell, you can
-          move around the board and press '1' to set a cell gray, or
-          '0' or backspace to return to white.
+          In Slitherlink, the goal is to draw one continuous line along
+          the borders between cells (see Rules tab). To create the borders
+          you can use the mouse or keyboard buttons:
+          <ul>
+            <li>
+              A <b>left-click</b> on the space between cells creates a border
+              line between vertices, while a <b>right-click</b> removes an
+              existing border line.
+            </li>
+            <li>
+              You can <b>drag</b> around to continue to draw the border line,
+              or erase an existing line.
+            </li>
+            <li>
+              Alternately, once on a cell boundary, you can press the
+              <b>shift key</b> and then the <b>arrow keys</b> to add more
+              borders in the direction of arrow keys.
+            </li>
+            <li>
+              Additionally, once the cursor is on a border, you can press the
+              <b>space bar</b> to toggle the border state, or press
+              <b>'1'</b> to set, or <b>'0'</b> or <b>backspace</b> to clear.
+            </li>
+            <li>
+              You can use the mouse to <b>middle-click</b> on a line to add
+              an '&#xD7;' in a line space, indicating that it is marked as
+              disabled, i.e. determined by the user to not be able to contain
+              a line. Similarly you can press the <b>X</b> key while the
+              cursor is on a border to set as disabled.
+            </li>
+            <li>
+              To help visualize the growing shape, you can <b>left-click</b>
+              on a cell to toggle its color between the default white, and gray.
+              This has no influence on the solving of the puzzle, but can help
+              visualize the cells in between the lines of the full final loop
+              (see rules). Once clicked, you can <b>drag</b> the mouse to
+              add to the gray coloration.  A <b>right-click</b> on a cell clears
+              it back to white, and a <b>right-click drag</b> can clear multiple
+              cells at once.
+            </li>
+            <li>
+              With the <b>arrow keys</b> you can move around the board and
+              press <b>'1'</b> to set a cell gray, or <b>'0'</b> or
+              <b>backspace</b> to return to white. Once on a cell of
+              either color, you can press and hold the <b>shift key</b> and
+              then move around the board with the <b>arrow keys</b> to
+              "paint" that color across cells.
+            </li>
+          </ul>
         </p>
         <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete numbers is indicated.  In Assist Mode (1), the
           number of errors and incomplete numbers is indicated, see game rules.
           In Assist Mode (2) errors are highlighted with cell or digit
@@ -61,10 +93,10 @@
           to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle code 0 shows an example completed
-          puzzle that can be helpful. The following puzzle codes have demos,
+          (see "Puzzles" tab). <b>Puzzle code 0</b> shows an example completed
+          puzzle that can be helpful. The following puzzle codes have <b>demos</b>,
           which will walk you through a solve to help you on the path to
           mastery: <span id='demolist1'>[]</span>).
         </p>
@@ -95,11 +127,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the

--- a/yajilin.html
+++ b/yajilin.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./puzzles.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans|Hina+Mincho"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:Bold,400|Hina+Mincho"/>
     <script type="application/javascript" src="./fastclick.js"></script>
     <script type="text/javascript" src="./render.js"></script>
     <script type="text/javascript" src="./yjpuzzles.js"></script>
@@ -28,39 +28,71 @@
     <div id="tabsContent">
       <div id="tab1" class="tab_content" style="display: block;">
         <p>
-          To set the colors of cells, right-click on a cell to turn dark,
-          or middle-click to turn white.  Alternately, you can use the
-          arrow keys to move around the board, and press the space bar
-          to toggle between the states, the '1' key to turn black,
-          or the '0' key to turn white.  You can not alter the state
-          of a square with a number and arrow value.
-        </p>
-        <p>
-          To draw a path, left click on the center of a white cell to
-          begin. From there, drag the mouse in the direction to create
-          the path. The path will draw as the dragging continues. Alternately,
-          once on the board, you can press the shift key and hold while
-          moving around the board with the arrow keys. In addition, you
-          can enter a key to indicate the type of path desired for that
-          cell (and into its neighbors). These keys are as follows, and
-          will extend the line into the center of the adjoining cells:
+          In the game Yajilin, the user sets some cells black, and
+          creates one continuous line through the remaining white
+          cells to satisfy the requirements of pre-set number
+          cells (see Rules tab). To set the colors and draw the
+          lines, you can use the mouse or keyboard keys:
           <ul>
-            <li>'-' key to draw a full horizontal line through the cell</li>
-            <li>'|' or 'I' key to draw a full vertical line through the cell</li>
-            <li>'L','J','7', or 'F' key to draw a correspondingly shaped turn in the cell</li>
+            <li>
+              Press the <b>right mouse button</b> to turn a cell
+              black, or <b>middle mouse</b> to return to white.
+            </li>
+            <li>
+              Alternately, you can use the <b>arrow keys</b> to move
+              around the board, and press the <b>space bar</b> to
+              toggle between the states, the <b>'1'</b> key to turn
+              black, or the <b>'0'</b> key to turn white.  You can
+              not alter the state of a square with a number and arrow value.
+            </li>
+            <li>
+              To draw a path, <b>left click</b> on the center of a
+              white cell to begin. From there, <b>drag</b> the mouse
+              in the direction to create the path. The path will draw
+              as the dragging continues.
+            </li>
+            <li>
+              Alternately, once on the board, you can press the
+              <b>shift key</b> and hold while moving around the board with
+              the <b>arrow keys</b>.
+            </li>
+            <li>
+              In addition, you can enter a key to indicate the type of
+              path desired for that cell (and into its neighbors). These
+              keys are as follows, and will extend the line into the
+              center of the adjoining cells:
+              <ul>
+                <li>
+                  <b>'-' key</b> to draw a full horizontal line
+                  through the cell
+                </li>
+                <li>
+                  <b>'|'</b> or <b>'I'</b> key to draw a full
+                  vertical line through the cell
+                </li>
+                <li>
+                  <b>'L','F','7'</b>, or <b>'7'</b> key to draw a
+                  correspondingly shaped turn in the cell (i.e.
+                  a left turn starting from the N, E, S, or
+                  W direction).
+                </li>
+              </ul>
+            </li>
+            <li>
+              Once created, a path can be removed by pressing the
+              <b>backspace</b> key within a white cell. This deletes
+              it just for this cell, but deletes the "arms" into the
+              adjoining cells.
+            </li>
+            <li>
+              You can press the <b>'.'</b> key to temporarily insert
+              a dot in a cell as a visual reminder that it will eventually
+              need a path. A <b>backspace</b> clears the dot.
+            </li>
           </ul>
-          Once created, a path can be removed by pressing the backspace
-          key within a white cell. This deletes it just for this cell,
-          but deletes the "arms" into the adjoining cells. You can also
-          attempt to redraw with the left-click dragging method.
         </p>
         <p>
-          You can press the '.' key to temporarily insert a dot in a
-          cell to indicate that it will eventually need a path. A
-          backspace clears the dot.
-        </p>
-        <p>
-          In Assist Mode (0), the default, only the existance of errors
+          In <b>Assist Mode</b> (0), the default, only the existance of errors
           or incomplete numbers is indicated.  In Assist Mode (1), the
           number of errors and incomplete numbers is indicated, see game rules.
           In Assist Mode (2), errors and completed rules are highlighted
@@ -71,10 +103,10 @@
           the "undo" button on the bottom of the page to undo previous moves.
         </p>
         <p>
-          Below, enter puzzle code (0-<span id='puzzlecount1'>0</span>)
+          Below, enter <b>puzzle code (0-<span id='puzzlecount1'>0</span>)</b>
           for one of a list of pre-defined puzzles, or a puzzle descriptor
-          (see "Puzzles" tab). Puzzle 0 shows an example of a completed
-          puzzle. The following puzzle codes have demos, which will walk
+          (see "Puzzles" tab). <b>Puzzle 0</b> shows an example of a completed
+          puzzle. The following puzzle codes have <b>demos</b>, which will walk
           you through a solve to help you on the path to mastery:
           <span id='demolist1'>[]</span>).
         </p>
@@ -122,11 +154,11 @@
       <div id="tab3" class="tab_content" style="display: none;">
         <p>
           Puzzles can be invoked by either a numerical entry from
-          0-<span id='puzzlecount2'>0</span>, or through a character
+          <b>0-<span id='puzzlecount2'>0</span></b>, or through a character
           description of the puzzle itself, entered into the Display
           form on the 'Game Play' tab. The numbered puzzles are
           hand-crafted of varying difficulty, roughly easy to hard.
-          Puzzle 0 shows a completed correct puzzle.
+          <b>Puzzle 0</b> shows a completed correct puzzle.
         </p>
         <p>
           To describe a puzzle, the character string must be of the


### PR DESCRIPTION
Fixes #74 

This does a small change to all of the HTML files to attempt to make the "Game Play" tabs more readable, as well as to "introduce" the puzzle and point to the "Rules tab". In addition, it highlights movement instructions with **bold**, and a few other keywords/key items with **bold** such as the existence of demos, and the use of the assist mode.